### PR TITLE
feat: shared lint config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ run/
 .env.local
 
 /nats-iam-broker
+.shared/

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,15 @@ test-race:
 view-coverage: test-race
 	go tool cover -html=coverage.out
 
-lint:
+sync-shared-lint:
+	@mkdir -p .shared
+	@curl -sfL "https://raw.githubusercontent.com/jr200-labs/github-action-templates/master/shared/sync-shared-lint.sh" -o .shared/sync-shared-lint.sh
+	@chmod +x .shared/sync-shared-lint.sh
+	@./.shared/sync-shared-lint.sh go
+
+lint: sync-shared-lint
 	go vet ./...
-	golangci-lint run --timeout=5m
+	golangci-lint run --config .shared/.golangci.yml --timeout=5m
 
 build:
 	go mod tidy

--- a/cmd/nats-iam-broker/decrypt.go
+++ b/cmd/nats-iam-broker/decrypt.go
@@ -56,7 +56,7 @@ func runDecodeNATSJWT(token string) error {
 	if err != nil {
 		return fmt.Errorf("error decoding NATS JWT: %w", err)
 	}
-	fmt.Fprintf(os.Stdout, "=== NATS JWT ===\n%s\n", decoded)
+	_, _ = fmt.Fprintf(os.Stdout, "=== NATS JWT ===\n%s\n", decoded)
 	return nil
 }
 
@@ -71,10 +71,10 @@ func runDecodeJWEToken(token, keyStr string) error {
 	if err != nil {
 		return fmt.Errorf("error marshalling JWE header: %w", err)
 	}
-	fmt.Fprintf(os.Stdout, "=== JWE Header ===\n%s\n", headerJSON)
+	_, _ = fmt.Fprintf(os.Stdout, "=== JWE Header ===\n%s\n", headerJSON)
 
 	if keyStr == "" {
-		fmt.Fprintf(os.Stdout, "\nNo --key provided; only header shown. Provide --key to decrypt payload.\n")
+		_, _ = fmt.Fprintf(os.Stdout, "\nNo --key provided; only header shown. Provide --key to decrypt payload.\n")
 		return nil
 	}
 
@@ -90,7 +90,7 @@ func runDecodeJWEToken(token, keyStr string) error {
 
 	// Try to decode as a NATS JWT
 	if decoded, err := tryDecodeNATSJWT(string(plaintext)); err == nil {
-		fmt.Fprintf(os.Stdout, "\n=== Decrypted NATS JWT ===\n%s\n", decoded)
+		_, _ = fmt.Fprintf(os.Stdout, "\n=== Decrypted NATS JWT ===\n%s\n", decoded)
 		return nil
 	}
 
@@ -100,13 +100,13 @@ func runDecodeJWEToken(token, keyStr string) error {
 		var buf []byte
 		buf, err = json.MarshalIndent(raw, "", "  ")
 		if err == nil {
-			fmt.Fprintf(os.Stdout, "\n=== Decrypted Payload (JSON) ===\n%s\n", buf)
+			_, _ = fmt.Fprintf(os.Stdout, "\n=== Decrypted Payload (JSON) ===\n%s\n", buf)
 			return nil
 		}
 	}
 
 	// Fall back to raw output
-	fmt.Fprintf(os.Stdout, "\n=== Decrypted Payload (raw) ===\n%s\n", plaintext)
+	_, _ = fmt.Fprintf(os.Stdout, "\n=== Decrypted Payload (raw) ===\n%s\n", plaintext)
 	return nil
 }
 

--- a/internal/broker/auth_callback_test.go
+++ b/internal/broker/auth_callback_test.go
@@ -176,8 +176,8 @@ func TestBuildUserClaims_EndToEnd(t *testing.T) {
 		assert.Equal(t, f.userPub, resultClaims.Subject)
 
 		// Verify permissions from role
-		assert.Contains(t, resultClaims.Pub.Allow, "test.>")
-		assert.Contains(t, resultClaims.Sub.Allow, "test.>")
+		assert.Contains(t, resultClaims.Permissions.Pub.Allow, "test.>")
+		assert.Contains(t, resultClaims.Permissions.Sub.Allow, "test.>")
 
 		// Verify expiry is clamped to IDP ceiling
 		assert.LessOrEqual(t, resultClaims.Expires, idpExpiry)

--- a/internal/broker/auth_callback_test.go
+++ b/internal/broker/auth_callback_test.go
@@ -176,8 +176,8 @@ func TestBuildUserClaims_EndToEnd(t *testing.T) {
 		assert.Equal(t, f.userPub, resultClaims.Subject)
 
 		// Verify permissions from role
-		assert.Contains(t, resultClaims.Permissions.Pub.Allow, "test.>")
-		assert.Contains(t, resultClaims.Permissions.Sub.Allow, "test.>")
+		assert.Contains(t, resultClaims.Pub.Allow, "test.>")
+		assert.Contains(t, resultClaims.Sub.Allow, "test.>")
 
 		// Verify expiry is clamped to IDP ceiling
 		assert.LessOrEqual(t, resultClaims.Expires, idpExpiry)

--- a/internal/broker/auth_callback_test.go
+++ b/internal/broker/auth_callback_test.go
@@ -94,7 +94,7 @@ rbac:
 	require.NoError(t, err)
 	_, err = tmpFile.WriteString(configYAML)
 	require.NoError(t, err)
-	tmpFile.Close()
+	require.NoError(t, tmpFile.Close())
 
 	cm, err := NewConfigManager([]string{tmpFile.Name()})
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ rbac:
 	ctx := NewServerContext(&Options{LogSensitive: false})
 
 	t.Cleanup(func() {
-		os.Remove(tmpFile.Name())
+		_ = os.Remove(tmpFile.Name())
 	})
 
 	return &testFixture{
@@ -259,10 +259,10 @@ rbac:
 
 		tmpFile, err := os.CreateTemp("", "expiry-test-*.yaml")
 		require.NoError(t, err)
-		defer os.Remove(tmpFile.Name())
+		defer func() { _ = os.Remove(tmpFile.Name()) }()
 		_, err = tmpFile.WriteString(longExpiryCfg)
 		require.NoError(t, err)
-		tmpFile.Close()
+		require.NoError(t, tmpFile.Close())
 
 		cm, err := NewConfigManager([]string{tmpFile.Name()})
 		require.NoError(t, err)

--- a/internal/broker/config.go
+++ b/internal/broker/config.go
@@ -69,17 +69,17 @@ type NATS struct {
 }
 
 type Service struct {
-	Name        string         `yaml:"name" validate:"required"`
-	Description string         `yaml:"description" validate:"required"`
+	Name        string `yaml:"name" validate:"required"`
+	Description string `yaml:"description" validate:"required"`
 	// Version is optional. If empty, the broker resolves the runtime
 	// service version from (in order) the IAM_SERVICE_VERSION env var,
 	// the ldflags-injected internal/version.Version, then "dev". See
 	// internal/broker.ResolveServiceVersion. When provided, must still
 	// be valid semver. Historically required; relaxed in v1.3.0 so the
 	// running image tag (injected via Helm) becomes the source of truth.
-	Version     string         `yaml:"version" validate:"omitempty,semver"`
-	CredsFile   string         `yaml:"creds_file" validate:"required"`
-	Account     ServiceAccount `yaml:"account" validate:"required"`
+	Version   string         `yaml:"version" validate:"omitempty,semver"`
+	CredsFile string         `yaml:"creds_file" validate:"required"`
+	Account   ServiceAccount `yaml:"account" validate:"required"`
 }
 
 type ServiceAccount struct {

--- a/internal/broker/config_test.go
+++ b/internal/broker/config_test.go
@@ -59,7 +59,7 @@ rbac:
 	// Write test config to temp file
 	baseFile, err := os.CreateTemp("", "base-*.yaml")
 	require.NoError(t, err)
-	defer os.Remove(baseFile.Name())
+	defer func() { _ = os.Remove(baseFile.Name()) }()
 	_, err = baseFile.WriteString(baseConfig)
 	require.NoError(t, err)
 
@@ -527,7 +527,7 @@ rbac:
 
 	baseFile, err := os.CreateTemp("", "concurrent-*.yaml")
 	require.NoError(t, err)
-	defer os.Remove(baseFile.Name())
+	defer func() { _ = os.Remove(baseFile.Name()) }()
 	_, err = baseFile.WriteString(baseConfig)
 	require.NoError(t, err)
 

--- a/internal/broker/config_watcher.go
+++ b/internal/broker/config_watcher.go
@@ -72,7 +72,7 @@ func (cw *ConfigWatcher) Start() error {
 	dirs := uniqueDirs(paths)
 	for _, dir := range dirs {
 		if err := watcher.Add(dir); err != nil {
-			watcher.Close()
+			_ = watcher.Close()
 			return fmt.Errorf("failed to watch directory %s: %w", dir, err)
 		}
 		zap.L().Debug("watching directory for config changes", zap.String("dir", dir))
@@ -98,7 +98,7 @@ func (cw *ConfigWatcher) Start() error {
 func (cw *ConfigWatcher) Stop() {
 	close(cw.stopCh)
 	if cw.watcher != nil {
-		cw.watcher.Close()
+		_ = cw.watcher.Close()
 	}
 }
 

--- a/internal/broker/template_fns.go
+++ b/internal/broker/template_fns.go
@@ -38,7 +38,7 @@ func readNthLine(n int, filePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	for i := 0; scanner.Scan(); i++ {


### PR DESCRIPTION
Wire up shared .golangci.yml from jr200-labs/github-action-templates.

- Makefile lint target syncs shared config and passes `--config .shared/.golangci.yml`
- Fix errcheck violations (unchecked Close, Fprintf, os.Remove)
- Add `.shared/` to .gitignore

Refs: JRL-27