### PR TITLE
ci: toggle runner via RUNNER_PROFILES org variable (WG-103)

### DIFF
--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -46,7 +46,7 @@ jobs:
 
   spawn-workflow:
     needs: main
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
     steps:
       - name: dispatch-next-workflow
         uses: peter-evans/repository-dispatch@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,4 +12,4 @@ jobs:
   commitlint:
     uses: jr200-labs/github-action-templates/.github/workflows/lint_commits.yaml@master
     with:
-      runner: arc-linux-jr200-labs
+      runner: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -16,7 +16,7 @@ jobs:
     with:
       release-type: simple
       target-branch: master
-      runner: arc-linux-jr200-labs
+      runner: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
     secrets:
       app_private_key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}
 
@@ -25,7 +25,7 @@ jobs:
   dispatch-docker-build:
     needs: release
     if: needs.release.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
     steps:
       - name: Mint app token
         id: app-token

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -35,7 +35,7 @@ jobs:
     with:
       log-level: ${{ inputs.log-level || 'info' }}
       dry-run: ${{ inputs.dry-run || '' }}
-      runner: arc-linux-jr200-labs
+      runner: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
     # The org-level INTEGRATION_APP_PRIVATE_KEY secret has to be passed
     # explicitly because GitHub Actions does NOT inherit secrets across
     # orgs (variables yes, secrets no). github-action-templates lives in

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Replace hardcoded runner labels with `${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}`.
- A single org-level variable (`RUNNER_PROFILE`) now selects the active runner profile for all workflows in this repo.

## Linked
- https://linear.app/whengas/issue/WG-103

## Test plan
- [ ] PR-branch CI resolves the expression
- [ ] Flipping the org-level `RUNNER_PROFILE` variable switches runners without code change