### PR TITLE
ci: wire lint-workflow-runners reusable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,15 @@ on:
     branches: [master]
   workflow_dispatch:
 
+# Top-level permissions cascade into reusable workflow jobs. Repo
+# default_workflow_permissions is `read` (contents only) + `none` for
+# everything else, which downgrades the reusables' declared
+# `pull-requests: read` to `pull-requests: none` and makes the workflow
+# fail to start. Declare the union here so the reusables can run.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   ci:
     uses: jr200-labs/github-action-templates/.github/workflows/ci_go.yaml@master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,3 +13,6 @@ jobs:
     uses: jr200-labs/github-action-templates/.github/workflows/lint_commits.yaml@master
     with:
       runner: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
+
+  lint-workflow-runners:
+    uses: jr200-labs/github-action-templates/.github/workflows/lint_workflow_runners.yaml@master


### PR DESCRIPTION
## Summary
- Add `lint-workflow-runners` job to ci.yaml calling the shared reusable workflow from jr200-labs/github-action-templates.

## Test plan
- [ ] CI green on PR