### PR TITLE
ci: adopt shared banned-words commitlint + PR metadata gate (JRL-31)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,3 +25,6 @@ jobs:
 
   lint-workflow-runners:
     uses: jr200-labs/github-action-templates/.github/workflows/lint_workflow_runners.yaml@master
+
+  lint-pr-metadata:
+    uses: jr200-labs/github-action-templates/.github/workflows/lint_pr_metadata.yaml@master

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,3 +1,1 @@
-export default {
-  extends: ['@commitlint/config-conventional'],
-}
+export { default } from './.shared/commitlint.config.mjs';


### PR DESCRIPTION
## Summary

- Switch `commitlint.config.mjs` to re-export the shared config so the `banned-words` rule runs here.
- Add `lint-pr-metadata` job calling the new reusable workflow — gates branch name, PR title, PR body against the same `BANNED_COMMIT_WORDS` org var.

Linear: https://linear.app/jr200-labs/issue/JRL-31

## Test plan

- [ ] Confirm normal commits still pass commitlint.
- [ ] Verify `lint-pr-metadata` job runs and passes on this PR (clean metadata).
- [ ] Follow-up test PR with a banned word in commit / PR title / PR body / branch name to prove each surface fails independently.
- [ ] Roll out to remaining jr200-labs repos once green.