### PR TITLE
fix(ci): add top-level permissions for build_docker_image (JRL-32)

### DIFF
--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -24,6 +24,10 @@ on:
         default: |-
           [ "linux/amd64" ]
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   configure:
     uses: jr200-labs/github-action-templates/.github/workflows/preconfigure.yaml@master


### PR DESCRIPTION
Mechanical fix from the JRL-32 audit: add the load-bearing top-level `permissions:` block to `build_docker_image.yaml`.

The reusable workflow `jr200-labs/github-action-templates/.github/workflows/build_docker_image_multiplatform.yaml` declares `packages: write` and `contents: write` at the job level — but only the *caller's top-level* permissions cascade into reusables. Without this block, GitHub silently downgrades the call to the org default and the reusable startup-fails with `nested job 'build' is requesting 'packages: write', but is only allowed 'packages: read'`. This is exactly how `jr200-labs/keymint` v1.0.0 silently never published — see jr200-labs/keymint#19.

Today this caller happens to work because the org's `default_workflow_permissions` is set to `write`. The explicit grant insulates the workflow from any future tightening of that default and removes the latent failure mode.

No other changes. Broader drift cleanup (placement style, secret payload shapes, runner forwarding) is tracked in JRL-32 — https://linear.app/jr200-labs/issue/JRL-32 — which will fold these caller workflows into sync-shared so this class of drift can't recur.