### PR TITLE
ci: adopt canonical helm-chart group (JRL-32 phase 1.5)

### DIFF
--- a/.github/.shared-config.yaml
+++ b/.github/.shared-config.yaml
@@ -6,4 +6,5 @@ workflows:
   - hygiene
   - go
   - docker
+  - helm-chart
   - release

--- a/.github/workflows/build-helm-chart.yaml
+++ b/.github/workflows/build-helm-chart.yaml
@@ -1,30 +1,29 @@
 name: build-helm-chart
 
-on:
-  # Bespoke caller (helm-chart not yet a canonical group — JRL-32 phase 1.5).
-  # Listens on the same single release-published event the canonical
-  # release-please.yaml fires so a tag publishes docker + chart in parallel.
-  repository_dispatch:
-    types:
-      - release-published
+# Triggered by release-please publishing a tag. Builds + uploads a
+# Helm chart to the org's chart repo. Verbatim across consumers; each
+# consuming org must define:
+#   - vars.HELM_CHART_REPO       (e.g. jr200/helm-charts-private)
+#   - secrets.CHARTS_WRITE_TOKEN (PAT with contents:write on that repo)
 
+on:
+  repository_dispatch:
+    types: [release-published]
   workflow_dispatch:
     inputs:
       checkout-ref:
         description: "checkout ref"
         required: false
         type: string
-        default: "refs/heads/main"
-      chart_repo:
-        description: "charts repo"
-        required: true
+        default: "refs/heads/master"
+      tag:
+        description: chart-version
+        required: false
         type: string
-        default: jr200/helm-charts-private
-      chart_dir:
-        description: "charts folder"
-        required: true
-        type: string
-        default: charts
+        default: dev
+
+permissions:
+  contents: read
 
 jobs:
   configure:
@@ -38,8 +37,6 @@ jobs:
     uses: jr200-labs/github-action-templates/.github/workflows/build_helm_chart.yaml@master
     with:
       checkout-ref: ${{ fromJson(needs.configure.outputs.context).checkout-ref }}
-      chart_repo: ${{ fromJson(needs.configure.outputs.context).chart_repo }}
-      chart_dir: ${{ fromJson(needs.configure.outputs.context).chart_dir }}
+      chart_repo: ${{ vars.HELM_CHART_REPO }}
     secrets:
       charts_write_token: ${{ secrets.CHARTS_WRITE_TOKEN }}
-


### PR DESCRIPTION
Bespoke `build_helm_chart.yaml` was a hand-authored caller for the helm-chart reusable, kept while the helm-chart group was deferred. Phase 1.5 landed it; this repo adopts it.

`vars.HELM_CHART_REPO` (= `jr200/helm-charts-private`) and `secrets.CHARTS_WRITE_TOKEN` are already org-scoped, so no per-repo setup needed.

Trigger model unchanged — both old and new listen on `release-published` repository_dispatch from canonical release-please.yaml.