### PR TITLE
ci: sync-shared canonical caller workflows

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -56,3 +56,11 @@ jobs:
     secrets:
       registry_username: ${{ github.actor }}
       registry_token: ${{ secrets.GITHUB_TOKEN }}
+      # GitHub App auth for cloning private git deps at build time
+      # (e.g. uv sync over `pkg @ git+https://github.com/<org>/<repo>`).
+      # The reusable mints an installation token and writes /tmp/.netrc
+      # only when both are non-empty; repos with no private deps can
+      # leave the org-level INTEGRATION_* unset and these resolve to ''
+      # without breaking the build.
+      client_id: ${{ vars.INTEGRATION_CLIENT_ID }}
+      app_private_key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}

--- a/.github/workflows/lint-no-auto-merge.yaml
+++ b/.github/workflows/lint-no-auto-merge.yaml
@@ -1,0 +1,13 @@
+name: lint-no-auto-merge
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint-no-auto-merge:
+    uses: jr200-labs/github-action-templates/.github/workflows/lint_no_auto_merge.yaml@master

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -6,13 +6,14 @@ on:
   workflow_dispatch:
 
 # Only the caller's TOP-LEVEL permissions cascade into reusable
-# workflows. The reusable's renovate job needs all three writes —
-# without this block GitHub silently downgrades to read and the call
-# startup-fails. See AGENTS.md.
+# workflows. The reusable's renovate job needs contents/issues/PR
+# writes for repo state + actions:read for its post-step that fetches
+# the job log to detect package-lookup failures. See AGENTS.md.
 permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: read
 
 jobs:
   renovate:


### PR DESCRIPTION
Pulls the build-docker-image canonical caller fix from https://github.com/jr200-labs/github-action-templates/pull/104 forwarding INTEGRATION_CLIENT_ID + INTEGRATION_APP_PRIVATE_KEY so private git deps can be cloned during docker build. May also pick up unrelated canonical drift if the consumer is behind on syncs.