### PR TITLE
docs: fix README docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ nats-iam-broker serve --watch --metrics env.yaml idp.yaml rbac.yaml
 
 ## Documentation
 
-Full documentation is available at: https://jr200.github.io/nats-iam-broker/
+Full documentation is available at: https://jr200-labs.github.io/nats-iam-broker/
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- update the top-level README docs link from jr200 to jr200-labs

## Testing
- not run (documentation-only change)