### PR TITLE
fix: sync shared workflow callers

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -73,7 +73,7 @@ jobs:
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           ref: ${{ fromJson(needs.configure.outputs.context).checkout-ref }}
           sparse-checkout: |

--- a/.github/workflows/drift-check.yaml
+++ b/.github/workflows/drift-check.yaml
@@ -19,5 +19,5 @@ jobs:
   drift-check:
     runs-on: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
       - run: ./scripts/sync-shared-drift-check

--- a/.github/workflows/sync-shared-drift.yaml
+++ b/.github/workflows/sync-shared-drift.yaml
@@ -1,5 +1,6 @@
 # GENERATED/SHARED WORKFLOW: copied into consuming repos by sync-shared.
-# Do not edit in consuming repos; change jr200-labs/github-action-templates and sync.
+# DO NOT MANUALLY MODIFY THIS FILE IN A CONSUMER REPO.
+# Always edit the source workflow in jr200-labs/github-action-templates, then sync.
 name: sync-shared-drift
 
 # If the shared workflow drift check fails, repair the default branch by
@@ -25,9 +26,21 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure'
     runs-on: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
     steps:
-      - uses: actions/checkout@v7
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{ vars.INTEGRATION_CLIENT_ID }}
+          private-key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
+
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Sync shared workflow callers
         run: ./scripts/sync-shared
@@ -35,6 +48,7 @@ jobs:
       - name: Create drift repair PR
         uses: peter-evans/create-pull-request@v8.1.1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           branch: chore/sync-shared-workflows
           delete-branch: true
           commit-message: "chore: sync shared workflows"


### PR DESCRIPTION
## Summary
- Sync generated shared workflow callers for shared-v0.1.10.
- Restore the drift repair workflow app token with permission-workflows: write so generated workflow updates can be pushed to the repair PR branch.

## Verification
- SYNC_BASE_URL=file:///private/tmp/nats-shared-v0.1.10/consumers ./scripts/sync-shared-drift-check
- ./scripts/sync-shared-drift-check
- yq eval . .github/workflows/*.yaml >/dev/null
- git diff --check