### PR TITLE
feat: add SHA-256 template function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,8 @@ repos:
   - repo: https://github.com/golangci/golangci-lint
     rev: v2.11.4
     hooks:
-      # Formatter — runs `golangci-lint fmt` (gofmt + goimports + gofumpt as
-      # configured in .shared/.golangci.yml).
       - id: golangci-lint-fmt
         args: [--config=.shared/.golangci.yml]
-      # Linter — fast mode (--new-from-rev HEAD). CI runs the full mode.
       - id: golangci-lint
         args: [--config=.shared/.golangci.yml]
 

--- a/charts/nats-iam-broker/values.yaml
+++ b/charts/nats-iam-broker/values.yaml
@@ -89,6 +89,7 @@ server:
 #   {{ readFile "/path/file" }}     - read entire file contents
 #   {{ readNthLine N "/path/file" }}- read the Nth line of a file (0-indexed)
 #   {{ b64encode .field }}          - base64-encode a value
+#   {{ sha256hex .field }}           - SHA-256 hex-encode a value
 # ---------------------------------------------------------------------------
 config:
 

--- a/internal/broker/template_fns.go
+++ b/internal/broker/template_fns.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"bufio"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -14,6 +15,10 @@ import (
 
 func b64Encode(input string) string {
 	return base64.StdEncoding.EncodeToString([]byte(input))
+}
+
+func sha256Hex(input string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(input)))
 }
 
 func trim(input string) string {
@@ -81,6 +86,7 @@ func strJoin(input []interface{}, separators ...string) string {
 func templateFuncMap() template.FuncMap {
 	return template.FuncMap{
 		"b64encode":   b64Encode,
+		"sha256hex":   sha256Hex,
 		"concat":      concat,
 		"expandEnv":   expandEnv,
 		"env":         readEnv,

--- a/internal/broker/template_fns_test.go
+++ b/internal/broker/template_fns_test.go
@@ -199,6 +199,12 @@ func TestRenderAllTemplates(t *testing.T) {
 			expected: "aGVsbG8=",
 		},
 		{
+			name:     "sha256hex function",
+			content:  `{{sha256hex "hello"}}`,
+			mappings: map[string]interface{}{},
+			expected: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+		},
+		{
 			name:     "trim function",
 			content:  `{{trim "  spaced  "}}`,
 			mappings: map[string]interface{}{},
@@ -348,7 +354,7 @@ plain: no-template`
 
 func TestTemplateFuncMap(t *testing.T) {
 	fm := templateFuncMap()
-	expectedFuncs := []string{"b64encode", "concat", "expandEnv", "env", "readFile", "readNthLine", "strJoin", "trim"}
+	expectedFuncs := []string{"b64encode", "concat", "expandEnv", "env", "readFile", "readNthLine", "sha256hex", "strJoin", "trim"}
 	for _, name := range expectedFuncs {
 		assert.Contains(t, fm, name, "templateFuncMap should contain %s", name)
 	}


### PR DESCRIPTION
Adds sha256hex for deterministic, NATS-safe claim-derived subject segments.\n\nIncludes template coverage and chart documentation.